### PR TITLE
Fix missing $pkgdir in AUR PKGBUILD generation

### DIFF
--- a/build/update-pkgbuild.sh
+++ b/build/update-pkgbuild.sh
@@ -26,7 +26,7 @@ sha256sums_x86_64=('${X64_SUM}')
 sha256sums_aarch64=('${ARM64_SUM}')
 
 package() {
-  install -Dm755 stalker-gamma+linux.*.AppImage "$pkgdir/usr/bin/stalker-gamma"
+  install -Dm755 stalker-gamma+linux.*.AppImage "\${pkgdir}/usr/bin/stalker-gamma"
 }
 EOF
 )


### PR DESCRIPTION
The AUR package currently fails to build with `makepkg` (and helpers like yay/paru) throwing a "Permission denied" error. 

The `$pkgdir` variable in `update-pkgbuild.sh` was missing an escape character, which caused it to disappear when the `PKGBUILD` was generated by GitHub Actions. 

Because of this, the script was trying to install the app directly into the system's `/usr/bin/` folder instead of the safe package directory. 