### PR TITLE
No api

### DIFF
--- a/Stalker.Gamma/Extensions/ServiceCollectionExtensions.cs
+++ b/Stalker.Gamma/Extensions/ServiceCollectionExtensions.cs
@@ -39,6 +39,8 @@ public static class ServiceCollectionExtensions
             .AddScoped<ModDbUtility>()
             .AddScoped<MirrorUtility>()
             .AddScoped<CurlUtility>()
+            .AddScoped<GetCanonicalLinkFromModDbStartLink>()
+            .AddScoped<GetModDbAddonMetadata>()
             .AddScoped<IGetStalkerModsFromLocal, GetStalkerModsFromLocal>()
             .AddScoped<ISeparatorsFactory, SeparatorsFactory>()
             .AddScoped<IGetStalkerModsFromApi, GetStalkerModsFromApi>()

--- a/Stalker.Gamma/Factories/DownloadableRecordFactory.cs
+++ b/Stalker.Gamma/Factories/DownloadableRecordFactory.cs
@@ -32,7 +32,9 @@ public class DownloadableRecordFactory(
     GammaProgress gammaProgress,
     ModDbUtility modDbUtility,
     ArchiveUtility archiveUtility,
-    GitUtility gitUtility
+    GitUtility gitUtility,
+    GetCanonicalLinkFromModDbStartLink getCanonicalLinkFromModDbStartLink,
+    GetModDbAddonMetadata getModDbAddonMetadata
 ) : IDownloadableRecordFactory
 {
     public IDownloadableRecord CreateSkippedRecord(IDownloadableRecord record) =>
@@ -89,13 +91,15 @@ public class DownloadableRecordFactory(
     ) =>
         [
             .. records
-                .Where(r => r is ModDbRecord)
-                .Cast<ModDbRecord>()
+                .OfType<ModDbRecord>()
                 .GroupBy(r => r.ArchiveName)
                 .Select(r => new ModDbRecordGroup(gammaProgress, r.ToList())),
             .. records
-                .Where(r => r is GithubRecord)
-                .Cast<GithubRecord>()
+                .OfType<ModDbRecordGetMetadata>()
+                .GroupBy(r => r.StartLink)
+                .Select(r => new ModDbRecordGetMetadataGroup(gammaProgress, r.ToList())),
+            .. records
+                .OfType<GithubRecord>()
                 .GroupBy(r => r.ArchiveName)
                 .Select(r => new GithubRecordGroup(gammaProgress, r.ToList())),
         ];
@@ -114,12 +118,51 @@ public class DownloadableRecordFactory(
             return true;
         }
 
+        if (TryParseModDbGetMetadataRecord(gammaDir, record, out var modDbGetMetadataRecord))
+        {
+            downloadableRecord = modDbGetMetadataRecord;
+            return true;
+        }
+
         if (TryParseGithubRecord(gammaDir, record, out var githubRecord))
         {
             downloadableRecord = githubRecord;
             return true;
         }
 
+        return false;
+    }
+
+    private bool TryParseModDbGetMetadataRecord(
+        string gammaDir,
+        ModPackMakerRecord record,
+        out ModDbRecordGetMetadata? downloadableRecord
+    )
+    {
+        downloadableRecord = null;
+        if (
+            !string.IsNullOrWhiteSpace(record.AddonName)
+            && string.IsNullOrWhiteSpace(record.ZipName)
+            && !string.IsNullOrWhiteSpace(record.DlLink)
+            && record.DlLink.Contains("moddb")
+        )
+        {
+            var outputDirName = $"{record.Counter}- {record.AddonName} {record.Patch}";
+            var instructions = ProcessInstructions(record.Instructions);
+            downloadableRecord = new ModDbRecordGetMetadata(
+                record.AddonName!,
+                record.DlLink,
+                instructions,
+                outputDirName,
+                gammaDir,
+                archiveUtility,
+                gammaProgress,
+                modDbUtility,
+                getCanonicalLinkFromModDbStartLink,
+                getModDbAddonMetadata
+            );
+            return true;
+        }
         return false;
     }
 
@@ -179,8 +222,11 @@ public class DownloadableRecordFactory(
                 || string.IsNullOrWhiteSpace(record.ZipName)
             )
             {
-                throw new DownloadableRecordFactoryException($"Invalid record: {record}");
+                // likely using the mod pack maker list from stalker_gamma repo with no moddb metadata
+                return false;
             }
+
+            // normal mod pack maker with moddb metadata
             var outputDirName = $"{record.Counter}- {record.AddonName} {record.Patch}";
             var instructions = ProcessInstructions(record.Instructions);
             downloadableRecord = new ModDbRecord(

--- a/Stalker.Gamma/GammaInstallerServices/AnomalyInstaller.cs
+++ b/Stalker.Gamma/GammaInstallerServices/AnomalyInstaller.cs
@@ -16,6 +16,7 @@ public class AnomalyInstaller(
 {
     public string Name { get; } = "Stalker Anomaly";
     public string ArchiveName { get; } = "Anomaly-1.5.3-Full.2.7z";
+    public string ArchiveNameZstd => Path.ChangeExtension(ArchiveName, "tar.zst");
     protected string StalkerAnomalyUrl = "https://www.moddb.com/downloads/start/277404";
     private const string NiceUrl =
         "https://www.moddb.com/mods/stalker-anomaly/downloads/stalker-anomaly-153";
@@ -28,18 +29,19 @@ public class AnomalyInstaller(
     private readonly ModDbUtility _modDbUtility = modDbUtility;
     private readonly ArchiveUtility _archiveUtility = archiveUtility;
     public string DownloadPath => Path.Join(_downloadDirectory, ArchiveName);
+    public string DownloadPathZstd => Path.Join(_downloadDirectory, ArchiveNameZstd);
     private string ExtractPath => _anomalyDir;
 
     public virtual async Task DownloadAsync(CancellationToken cancellationToken = default)
     {
         if (
-            !File.Exists(DownloadPath)
+            (!File.Exists(DownloadPathZstd) && !File.Exists(DownloadPath))
             || (
                 File.Exists(DownloadPath)
                 && await HashUtils.HashFile(
                     DownloadPath,
                     HashAlgorithmName.MD5,
-                    pct => OnProgress("Check MD5", pct),
+                    pct => OnProgress(GammaProgressType.CheckMd5, pct),
                     cancellationToken
                 ) != StalkerAnomalyMd5
             )
@@ -48,7 +50,7 @@ public class AnomalyInstaller(
             await _modDbUtility.GetModDbLinkCurl(
                 StalkerAnomalyUrl,
                 DownloadPath,
-                pct => OnProgress("Download", pct),
+                pct => OnProgress(GammaProgressType.Download, pct),
                 cancellationToken: cancellationToken
             );
             Downloaded = true;
@@ -57,21 +59,37 @@ public class AnomalyInstaller(
 
     public virtual async Task ExtractAsync(CancellationToken cancellationToken = default)
     {
-        await _archiveUtility.ExtractAsync(
-            DownloadPath,
-            ExtractPath,
-            pct => OnProgress("Extract", pct),
-            ct: cancellationToken
-        );
+        // TODO: This likely needs an extra extract on Windows
+        if (File.Exists(DownloadPathZstd))
+        {
+            await _archiveUtility.ExtractAsync(
+                DownloadPathZstd,
+                ExtractPath,
+                pct => OnProgress(GammaProgressType.Extract, pct),
+                ct: cancellationToken
+            );
+        }
+        else
+        {
+            await _archiveUtility.ExtractAsync(
+                DownloadPath,
+                ExtractPath,
+                pct => OnProgress(GammaProgressType.Extract, pct),
+                ct: cancellationToken
+            );
+        }
         _progress.IncrementCompletedMods();
     }
 
     public bool Downloaded { get; set; }
 
-    private void OnProgress(string operation, double pct) =>
+    private void OnProgress(GammaProgressType operation, double pct) =>
         _progress.OnProgressChanged(ProgFunc(operation, pct));
 
-    private GammaProgress.GammaInstallProgressEventArgs ProgFunc(string operation, double pct) =>
+    private GammaProgress.GammaInstallProgressEventArgs ProgFunc(
+        GammaProgressType operation,
+        double pct
+    ) =>
         new()
         {
             Name = Name,

--- a/Stalker.Gamma/GammaInstallerServices/GammaInstaller.cs
+++ b/Stalker.Gamma/GammaInstallerServices/GammaInstaller.cs
@@ -55,7 +55,7 @@ public class GammaInstaller(
 
     public virtual async Task FullInstallAsync(GammaInstallerArgs args)
     {
-        args.Mo2Version ??= OperatingSystem.IsWindows() ? "v2.5.2" : "v2.4.4";
+        args.Mo2Version = "v2.5.2";
         args.Cache = Path.IsPathRooted(args.Cache) ? args.Cache : Path.GetFullPath(args.Cache);
         args.Gamma = Path.IsPathRooted(args.Gamma) ? args.Gamma : Path.GetFullPath(args.Gamma);
         args.Anomaly = Path.IsPathRooted(args.Anomaly)
@@ -337,7 +337,7 @@ public class GammaInstaller(
 
     public virtual async Task UpdateAsync(InstallUpdatesArgs args)
     {
-        args.Mo2Version ??= OperatingSystem.IsWindows() ? "v2.5.2" : "v2.4.4";
+        args.Mo2Version = "v2.5.2";
         args.Cache = Path.IsPathRooted(args.Cache) ? args.Cache : Path.GetFullPath(args.Cache);
         args.Gamma = Path.IsPathRooted(args.Gamma) ? args.Gamma : Path.GetFullPath(args.Gamma);
         args.Anomaly = Path.IsPathRooted(args.Anomaly)

--- a/Stalker.Gamma/GammaInstallerServices/GammaInstaller.cs
+++ b/Stalker.Gamma/GammaInstallerServices/GammaInstaller.cs
@@ -76,14 +76,7 @@ public class GammaInstaller(
             await powerShellCmdBuilder.Build().ExecuteAsync(args.CancellationToken);
         }
 
-        var modpackMakerTxt =
-            string.IsNullOrWhiteSpace(args.ModPackMakerPath)
-                ? await getStalkerModsFromApi.GetModsAsync(args.CancellationToken)
-            : File.Exists(args.ModPackMakerPath)
-                ? await File.ReadAllTextAsync(args.ModPackMakerPath)
-            : throw new FileNotFoundException(
-                $"{nameof(args.ModPackMakerPath)} file not found: {args.ModPackMakerPath}"
-            );
+        var modpackMakerTxt = await GetModpackMakerTxt(args);
         var modpackMakerRecords = modListRecordFactory.Create(modpackMakerTxt);
         var separators = separatorsFactory.Create(modpackMakerRecords);
         var anomalyRecord = downloadableRecordFactory.CreateAnomalyRecord(
@@ -329,6 +322,17 @@ public class GammaInstaller(
         );
 
         internalProgress.Reset();
+    }
+
+    private async Task<string> GetModpackMakerTxt(GammaInstallerArgs args)
+    {
+        return string.IsNullOrWhiteSpace(args.ModPackMakerPath)
+                ? await getStalkerModsFromApi.GetModsAsync(args.CancellationToken)
+            : File.Exists(args.ModPackMakerPath)
+                ? await File.ReadAllTextAsync(args.ModPackMakerPath)
+            : throw new FileNotFoundException(
+                $"{nameof(args.ModPackMakerPath)} file not found: {args.ModPackMakerPath}"
+            );
     }
 
     public virtual async Task UpdateAsync(InstallUpdatesArgs args)
@@ -583,6 +587,10 @@ public class GammaInstaller(
                             grs.DeleteArchive();
                         }
                     }
+                }
+                catch (ModDbBotDetectedException)
+                {
+                    throw;
                 }
                 catch (Exception)
                 {

--- a/Stalker.Gamma/GammaInstallerServices/GammaProgress.cs
+++ b/Stalker.Gamma/GammaInstallerServices/GammaProgress.cs
@@ -1,3 +1,5 @@
+using System.Runtime.Serialization;
+
 namespace Stalker.Gamma.GammaInstallerServices;
 
 public interface IGammaProgress
@@ -5,6 +7,23 @@ public interface IGammaProgress
     int TotalMods { get; set; }
     event EventHandler<GammaProgress.GammaInstallProgressEventArgs>? ProgressChanged;
     event EventHandler<GammaProgress.GammaInstallDebugProgressEventArgs>? DebugProgressChanged;
+}
+
+public static class GammaProgressExtensions
+{
+    extension(GammaProgressType e)
+    {
+        public string GetHumanReadableString() =>
+            e switch
+            {
+                GammaProgressType.Download => "Download",
+                GammaProgressType.Extract => "Extract",
+                GammaProgressType.Expand => "Expand",
+                GammaProgressType.CheckMd5 => "Check MD5",
+                GammaProgressType.Skipped => "Skipped",
+                _ => throw new ArgumentOutOfRangeException(nameof(e), e, null),
+            };
+    }
 }
 
 public class GammaProgress : IGammaProgress
@@ -44,7 +63,7 @@ public class GammaProgress : IGammaProgress
             IEquatable<GammaInstallProgressEventArgs>
     {
         public required string Name { get; init; }
-        public required string ProgressType { get; init; }
+        public required GammaProgressType ProgressType { get; init; }
         public required double Progress { get; init; }
         public required string Url { get; init; }
         public required string ArchiveName { get; init; }
@@ -92,4 +111,13 @@ public class GammaProgress : IGammaProgress
             );
         }
     }
+}
+
+public enum GammaProgressType
+{
+    Download,
+    Extract,
+    Expand,
+    CheckMd5,
+    Skipped,
 }

--- a/Stalker.Gamma/GammaInstallerServices/GetCanonicalLinkFromModDbStartLink.cs
+++ b/Stalker.Gamma/GammaInstallerServices/GetCanonicalLinkFromModDbStartLink.cs
@@ -1,0 +1,40 @@
+﻿using HtmlAgilityPack;
+using Stalker.Gamma.Utilities;
+
+namespace Stalker.Gamma.GammaInstallerServices;
+
+public class GetCanonicalLinkFromModDbStartLink(CurlUtility curlUtility)
+{
+    public async Task<string> GetCanonicalLinkAsync(
+        string modDbStartLink,
+        CancellationToken ct = default
+    )
+    {
+        try
+        {
+            var htmlContent = await _curlUtility.GetStringAsync(modDbStartLink, ct);
+            var htmlDoc = new HtmlDocument();
+            htmlDoc.LoadHtml(htmlContent);
+            var linkNode = htmlDoc.DocumentNode.SelectSingleNode("//link[@rel='canonical']");
+            var canonicalLink = linkNode?.GetAttributeValue("href", string.Empty);
+            return string.IsNullOrWhiteSpace(canonicalLink)
+                ? throw new CanonicalLinkNotFoundException(modDbStartLink)
+                : canonicalLink;
+        }
+        catch (Exception e)
+            when (e is not CanonicalLinkNotFoundException and not ModDbBotDetectedException)
+        {
+            throw new GetCanonicalLinkFromModDbStartLinkException(
+                $"Error retrieving canonical link from: {modDbStartLink}",
+                e
+            );
+        }
+    }
+
+    private readonly CurlUtility _curlUtility = curlUtility;
+}
+
+public class CanonicalLinkNotFoundException(string msg) : Exception(msg);
+
+public class GetCanonicalLinkFromModDbStartLinkException(string msg, Exception inner)
+    : Exception(msg, inner);

--- a/Stalker.Gamma/GammaInstallerServices/GetModDbAddonMetadata.cs
+++ b/Stalker.Gamma/GammaInstallerServices/GetModDbAddonMetadata.cs
@@ -1,0 +1,112 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+using HtmlAgilityPack;
+using Stalker.Gamma.Models;
+using Stalker.Gamma.Utilities;
+
+namespace Stalker.Gamma.GammaInstallerServices;
+
+public partial class GetModDbAddonMetadata(CurlUtility curlUtility)
+{
+    private readonly CurlUtility _curlUtility = curlUtility;
+
+    public async Task<ModDbPageMetadata> GetAsync(string modDbAddonUrl, CancellationToken ct)
+    {
+        var addonHtml = await _curlUtility.GetStringAsync(modDbAddonUrl, ct);
+        try
+        {
+            var htmlDoc = new HtmlDocument();
+            htmlDoc.LoadHtml(addonHtml);
+            var node = htmlDoc.DocumentNode.SelectNodes(
+                "//div[contains(@class, 'table') and contains(@class, 'tablemenu')]//div[contains(@class, 'row') and contains(@class, 'clear')]"
+            );
+            var modDbAddonMetadataDict = node.Select(n => new
+                {
+                    Title = n.ChildNodes.FirstOrDefault(cn => cn.Name == "h5")?.InnerText.Trim(),
+                    Value = n.ChildNodes.FirstOrDefault(cn => cn.Name == "span")?.InnerText.Trim(),
+                })
+                .Where(x =>
+                    !string.IsNullOrWhiteSpace(x.Title)
+                    && Wanted.Contains(x.Title)
+                    && !string.IsNullOrWhiteSpace(x.Value)
+                )
+                .ToDictionary(x => x.Title!, x => x.Value!);
+            modDbAddonMetadataDict.TryGetValue("Credits", out var credits);
+            return new ModDbPageMetadata
+            {
+                Url = modDbAddonUrl,
+                Added = DateTimeOffset.ParseExact(
+                    CleanDateRx().Replace(modDbAddonMetadataDict["Added"], ""),
+                    "MMM d, yyyy",
+                    CultureInfo.InvariantCulture
+                ),
+                Category = modDbAddonMetadataDict["Category"],
+                Credits = credits,
+                Downloads = long.Parse(
+                    modDbAddonMetadataDict["Downloads"].Split(' ')[0],
+                    NumberStyles.AllowThousands,
+                    provider: CultureInfo.InvariantCulture
+                ),
+                Filename = modDbAddonMetadataDict["Filename"],
+                Licence = modDbAddonMetadataDict["Licence"],
+                Location = modDbAddonMetadataDict["Location"],
+                Md5Hash = modDbAddonMetadataDict["MD5 Hash"],
+                Size = long.Parse(
+                    SizeRx().Match(modDbAddonMetadataDict["Size"]).Groups[1].Value,
+                    NumberStyles.AllowThousands,
+                    provider: CultureInfo.InvariantCulture
+                ),
+                Updated = modDbAddonMetadataDict.TryGetValue("Updated", out var updated)
+                    ? DateTimeOffset.ParseExact(
+                        CleanDateRx().Replace(updated, ""),
+                        "MMM d, yyyy",
+                        CultureInfo.InvariantCulture
+                    )
+                    : DateTimeOffset.ParseExact(
+                        CleanDateRx().Replace(modDbAddonMetadataDict["Added"], ""),
+                        "MMM d, yyyy",
+                        CultureInfo.InvariantCulture
+                    ),
+                Uploader = modDbAddonMetadataDict["Uploader"],
+            };
+        }
+        catch (ModDbBotDetectedException)
+        {
+            throw;
+        }
+        catch (Exception e)
+        {
+            throw new GetModDbAddonMetadataException(
+                $"""
+                Error getting metadata for {modDbAddonUrl}
+                Addon HTML: {addonHtml}
+                Exception message: {e.Message}
+                """,
+                e
+            );
+        }
+    }
+
+    [GeneratedRegex(@"(?<=\d)(st|nd|rd|th)")]
+    private partial Regex CleanDateRx();
+
+    [GeneratedRegex(@".*\((.*) bytes\)")]
+    private partial Regex SizeRx();
+
+    private static readonly HashSet<string> Wanted =
+    [
+        "Location",
+        "Filename",
+        "Category",
+        "Licence",
+        "Uploader",
+        "Credits",
+        "Added",
+        "Size",
+        "Downloads",
+        "MD5 Hash",
+    ];
+}
+
+public class GetModDbAddonMetadataException(string msg, Exception exception)
+    : Exception(msg, exception);

--- a/Stalker.Gamma/GammaInstallerServices/SpecialRepos/GammaLargeFiles.cs
+++ b/Stalker.Gamma/GammaInstallerServices/SpecialRepos/GammaLargeFiles.cs
@@ -32,7 +32,7 @@ public class GammaLargeFilesRepo(
                 _gitUtility.FetchGitRepo(
                     DownloadPath,
                     ct: ct,
-                    onProgress: pct => OnProgress("Download", pct)
+                    onProgress: pct => OnProgress(GammaProgressType.Download, pct)
                 );
             }
             else
@@ -40,7 +40,7 @@ public class GammaLargeFilesRepo(
                 _gitUtility.CloneGitRepo(
                     DownloadPath,
                     Url,
-                    onProgress: pct => OnProgress("Download", pct),
+                    onProgress: pct => OnProgress(GammaProgressType.Download, pct),
                     ct: ct,
                     bare: true
                 );
@@ -69,7 +69,7 @@ public class GammaLargeFilesRepo(
             DownloadPath,
             TempDir,
             ct: ct,
-            onProgress: pct => OnProgress("Extract", pct)
+            onProgress: pct => OnProgress(GammaProgressType.Extract, pct)
         );
 
     public virtual Task ExtractAsync(CancellationToken cancellationToken = default)
@@ -79,7 +79,7 @@ public class GammaLargeFilesRepo(
             DirUtils.CopyDirectory(
                 TempDir,
                 DestinationDir,
-                onProgress: pct => OnProgress("Extract", pct),
+                onProgress: pct => OnProgress(GammaProgressType.Extract, pct),
                 moveFile: true,
                 cancellationToken: cancellationToken
             );
@@ -94,10 +94,13 @@ public class GammaLargeFilesRepo(
         return Task.CompletedTask;
     }
 
-    private void OnProgress(string operation, double pct) =>
+    private void OnProgress(GammaProgressType operation, double pct) =>
         _gammaProgress.OnProgressChanged(ProgFunc(operation, pct));
 
-    private GammaProgress.GammaInstallProgressEventArgs ProgFunc(string operation, double pct) =>
+    private GammaProgress.GammaInstallProgressEventArgs ProgFunc(
+        GammaProgressType operation,
+        double pct
+    ) =>
         new()
         {
             Name = Name,

--- a/Stalker.Gamma/GammaInstallerServices/SpecialRepos/GammaSetup.cs
+++ b/Stalker.Gamma/GammaInstallerServices/SpecialRepos/GammaSetup.cs
@@ -29,7 +29,7 @@ public class GammaSetupRepo(
                 gitUtility.FetchGitRepo(
                     DownloadPath,
                     ct: cancellationToken,
-                    onProgress: pct => OnProgress("Download", pct)
+                    onProgress: pct => OnProgress(GammaProgressType.Download, pct)
                 );
             }
             else
@@ -37,7 +37,7 @@ public class GammaSetupRepo(
                 gitUtility.CloneGitRepo(
                     DownloadPath,
                     Url,
-                    onProgress: pct => OnProgress("Download", pct),
+                    onProgress: pct => OnProgress(GammaProgressType.Download, pct),
                     ct: cancellationToken,
                     bare: true
                 );
@@ -65,7 +65,7 @@ public class GammaSetupRepo(
             DownloadPath,
             TempDir,
             ct: ct,
-            onProgress: pct => OnProgress("Extract", pct)
+            onProgress: pct => OnProgress(GammaProgressType.Extract, pct)
         );
 
     public virtual Task ExtractAsync(CancellationToken cancellationToken = default)
@@ -75,7 +75,7 @@ public class GammaSetupRepo(
             DirUtils.CopyDirectory(
                 Path.Join(TempDir, "modpack_addons"),
                 GammaModsDir,
-                onProgress: pct => OnProgress("Extract", pct),
+                onProgress: pct => OnProgress(GammaProgressType.Extract, pct),
                 moveFile: true,
                 cancellationToken: cancellationToken
             );
@@ -92,10 +92,13 @@ public class GammaSetupRepo(
 
     public bool Downloaded { get; set; }
 
-    private void OnProgress(string operation, double pct) =>
+    private void OnProgress(GammaProgressType operation, double pct) =>
         _gammaProgress.OnProgressChanged(ProgFunc(operation, pct));
 
-    private GammaProgress.GammaInstallProgressEventArgs ProgFunc(string operation, double pct) =>
+    private GammaProgress.GammaInstallProgressEventArgs ProgFunc(
+        GammaProgressType operation,
+        double pct
+    ) =>
         new()
         {
             Name = Name,

--- a/Stalker.Gamma/GammaInstallerServices/SpecialRepos/StalkerGammaRepo.cs
+++ b/Stalker.Gamma/GammaInstallerServices/SpecialRepos/StalkerGammaRepo.cs
@@ -31,7 +31,7 @@ public class StalkerGammaRepo(
                 gitUtility.FetchGitRepo(
                     DownloadPath,
                     ct: cancellationToken,
-                    onProgress: pct => OnProgress("Download", pct)
+                    onProgress: pct => OnProgress(GammaProgressType.Download, pct)
                 );
             }
             else
@@ -39,7 +39,7 @@ public class StalkerGammaRepo(
                 gitUtility.CloneGitRepo(
                     DownloadPath,
                     Url,
-                    onProgress: pct => OnProgress("Download", pct),
+                    onProgress: pct => OnProgress(GammaProgressType.Download, pct),
                     ct: cancellationToken,
                     bare: true
                 );
@@ -68,7 +68,7 @@ public class StalkerGammaRepo(
             DownloadPath,
             TempDir,
             ct: ct,
-            onProgress: pct => OnProgress("Extract", pct)
+            onProgress: pct => OnProgress(GammaProgressType.Extract, pct)
         );
 
     public virtual Task ExtractAsync(CancellationToken cancellationToken = default)
@@ -78,14 +78,14 @@ public class StalkerGammaRepo(
             DirUtils.CopyDirectory(
                 Path.Join(TempDir, "G.A.M.M.A", "modpack_addons"),
                 GammaModsDir,
-                onProgress: pct => OnProgress("Extract", pct),
+                onProgress: pct => OnProgress(GammaProgressType.Extract, pct),
                 moveFile: true,
                 cancellationToken: cancellationToken
             );
             DirUtils.CopyDirectory(
                 Path.Join(TempDir, "G.A.M.M.A", "modpack_patches"),
                 AnomalyDir,
-                onProgress: pct => OnProgress("Extract", pct),
+                onProgress: pct => OnProgress(GammaProgressType.Extract, pct),
                 moveFile: true,
                 cancellationToken: cancellationToken
             );
@@ -107,10 +107,13 @@ public class StalkerGammaRepo(
 
     public bool Downloaded { get; set; }
 
-    private void OnProgress(string operation, double pct) =>
+    private void OnProgress(GammaProgressType operation, double pct) =>
         _gammaProgress.OnProgressChanged(ProgFunc(operation, pct));
 
-    private GammaProgress.GammaInstallProgressEventArgs ProgFunc(string operation, double pct) =>
+    private GammaProgress.GammaInstallProgressEventArgs ProgFunc(
+        GammaProgressType operation,
+        double pct
+    ) =>
         new()
         {
             Name = Name,

--- a/Stalker.Gamma/GammaInstallerServices/SpecialRepos/TeivazAnomalyGunslingerRepo.cs
+++ b/Stalker.Gamma/GammaInstallerServices/SpecialRepos/TeivazAnomalyGunslingerRepo.cs
@@ -36,7 +36,7 @@ public class TeivazAnomalyGunslingerRepo(
                 gitUtility.FetchGitRepo(
                     DownloadPath,
                     ct: cancellationToken,
-                    onProgress: pct => OnProgress("Download", pct)
+                    onProgress: pct => OnProgress(GammaProgressType.Download, pct)
                 );
             }
             else
@@ -44,7 +44,7 @@ public class TeivazAnomalyGunslingerRepo(
                 gitUtility.CloneGitRepo(
                     DownloadPath,
                     Url,
-                    onProgress: pct => OnProgress("Download", pct),
+                    onProgress: pct => OnProgress(GammaProgressType.Download, pct),
                     ct: cancellationToken,
                     bare: true
                 );
@@ -73,7 +73,7 @@ public class TeivazAnomalyGunslingerRepo(
             DownloadPath,
             TempDir,
             ct: ct,
-            onProgress: pct => OnProgress("Extract", pct)
+            onProgress: pct => OnProgress(GammaProgressType.Extract, pct)
         );
 
     public virtual Task ExtractAsync(CancellationToken cancellationToken = default)
@@ -89,7 +89,7 @@ public class TeivazAnomalyGunslingerRepo(
                     gameDataDir,
                     ExtractPath,
                     overwrite: true,
-                    onProgress: pct => OnProgress("Extract", pct),
+                    onProgress: pct => OnProgress(GammaProgressType.Extract, pct),
                     moveFile: true,
                     cancellationToken: cancellationToken
                 );
@@ -106,10 +106,13 @@ public class TeivazAnomalyGunslingerRepo(
 
     public bool Downloaded { get; set; }
 
-    private void OnProgress(string operation, double pct) =>
+    private void OnProgress(GammaProgressType operation, double pct) =>
         _gammaProgress.OnProgressChanged(ProgFunc(operation, pct));
 
-    private GammaProgress.GammaInstallProgressEventArgs ProgFunc(string operation, double pct) =>
+    private GammaProgress.GammaInstallProgressEventArgs ProgFunc(
+        GammaProgressType operation,
+        double pct
+    ) =>
         new()
         {
             Name = Name,

--- a/Stalker.Gamma/ModOrganizer/DownloadModOrganizer/DownloadModOrganizerService.cs
+++ b/Stalker.Gamma/ModOrganizer/DownloadModOrganizer/DownloadModOrganizerService.cs
@@ -90,7 +90,7 @@ public class DownloadModOrganizerService(
                     new GammaProgress.GammaInstallProgressEventArgs
                     {
                         Name = "ModOrganizer",
-                        ProgressType = "Extract",
+                        ProgressType = GammaProgressType.Extract,
                         Progress = pct,
                         Url = dlUrl,
                         ArchiveName = Path.GetFileName(mo2ArchivePath),
@@ -150,7 +150,7 @@ public class DownloadModOrganizerService(
                                     new GammaProgress.GammaInstallProgressEventArgs
                                     {
                                         Name = "ModOrganizer",
-                                        ProgressType = "Check MD5",
+                                        ProgressType = GammaProgressType.CheckMd5,
                                         Progress = pct,
                                         Url = dlUrl,
                                         ArchiveName = Path.GetFileName(mo2ArchivePath),
@@ -171,7 +171,7 @@ public class DownloadModOrganizerService(
                                     new GammaProgress.GammaInstallProgressEventArgs
                                     {
                                         Name = "ModOrganizer",
-                                        ProgressType = "Download",
+                                        ProgressType = GammaProgressType.Download,
                                         Progress = pct,
                                         Url = dlUrl,
                                         ArchiveName = Path.GetFileName(mo2ArchivePath),
@@ -194,7 +194,7 @@ public class DownloadModOrganizerService(
                                     new GammaProgress.GammaInstallProgressEventArgs
                                     {
                                         Name = "ModOrganizer",
-                                        ProgressType = "Check MD5",
+                                        ProgressType = GammaProgressType.CheckMd5,
                                         Progress = pct,
                                         Url = dlUrl,
                                         ArchiveName = Path.GetFileName(mo2ArchivePath),
@@ -215,7 +215,7 @@ public class DownloadModOrganizerService(
                                     new GammaProgress.GammaInstallProgressEventArgs
                                     {
                                         Name = "ModOrganizer",
-                                        ProgressType = "Download",
+                                        ProgressType = GammaProgressType.Download,
                                         Progress = pct,
                                         Url = dlUrl,
                                         ArchiveName = Path.GetFileName(mo2ArchivePath),
@@ -240,7 +240,7 @@ public class DownloadModOrganizerService(
                         new GammaProgress.GammaInstallProgressEventArgs
                         {
                             Name = "ModOrganizer",
-                            ProgressType = "Download",
+                            ProgressType = GammaProgressType.Download,
                             Progress = pct,
                             Url = dlUrl,
                             ArchiveName = Path.GetFileName(mo2ArchivePath),

--- a/Stalker.Gamma/ModOrganizer/DownloadModOrganizer/DownloadModOrganizerService.cs
+++ b/Stalker.Gamma/ModOrganizer/DownloadModOrganizer/DownloadModOrganizerService.cs
@@ -10,7 +10,7 @@ namespace Stalker.Gamma.ModOrganizer.DownloadModOrganizer;
 public interface IDownloadModOrganizerService
 {
     Task DownloadAsync(
-        string version = "v2.4.4",
+        string version = "v2.5.2",
         string cachePath = "",
         string? extractPath = null,
         CancellationToken cancellationToken = default
@@ -19,7 +19,7 @@ public interface IDownloadModOrganizerService
     void DeleteArchive(string cachePath = "");
 
     Task ExtractAsync(
-        string version = "v2.4.4",
+        string version = "v2.5.2",
         string cachePath = "",
         string? extractPath = null,
         string dlUrl = "",
@@ -35,7 +35,7 @@ public class DownloadModOrganizerService(
 ) : IDownloadModOrganizerService
 {
     public async Task ExtractAsync(
-        string version = "v2.4.4",
+        string version = "v2.5.2",
         string cachePath = "",
         string? extractPath = null,
         string dlUrl = "",
@@ -103,7 +103,7 @@ public class DownloadModOrganizerService(
     }
 
     public async Task DownloadAsync(
-        string version = "v2.4.4",
+        string version = "v2.5.2",
         string cachePath = "",
         string? extractPath = null,
         CancellationToken cancellationToken = default

--- a/Stalker.Gamma/Models/GithubRecord.cs
+++ b/Stalker.Gamma/Models/GithubRecord.cs
@@ -45,11 +45,11 @@ public class GithubRecord(
                 _hc,
                 Url,
                 DownloadPath,
-                onProgress: pct => OnProgress("Download", pct),
+                onProgress: pct => OnProgress(GammaProgressType.Download, pct),
                 cancellationToken: cancellationToken
             );
 
-            OnProgress("Download", 1);
+            OnProgress(GammaProgressType.Download, 1);
             Downloaded = true;
         }
         catch (Exception e)
@@ -81,7 +81,7 @@ public class GithubRecord(
             await _archiveUtility.ExtractAsync(
                 DownloadPath,
                 ExtractPath,
-                pct => OnProgress("Extract", pct),
+                pct => OnProgress(GammaProgressType.Extract, pct),
                 ct: cancellationToken
             );
 
@@ -120,10 +120,13 @@ public class GithubRecord(
             Instructions: {string.Join(", ", Instructions)}
             """;
 
-    private void OnProgress(string operation, double pct) =>
+    private void OnProgress(GammaProgressType operation, double pct) =>
         _gammaProgress.OnProgressChanged(ProgFunc(operation, pct));
 
-    private GammaProgress.GammaInstallProgressEventArgs ProgFunc(string operation, double pct) =>
+    private GammaProgress.GammaInstallProgressEventArgs ProgFunc(
+        GammaProgressType operation,
+        double pct
+    ) =>
         new()
         {
             Name = Name,

--- a/Stalker.Gamma/Models/ModDbPageMetaData.cs
+++ b/Stalker.Gamma/Models/ModDbPageMetaData.cs
@@ -1,0 +1,47 @@
+namespace Stalker.Gamma.Models;
+
+public class ModDbPageMetadata
+{
+    public required DateTimeOffset Added { get; set; }
+
+    public required string Category { get; set; }
+
+    public string? Credits { get; set; }
+
+    public required long Downloads { get; set; }
+
+    public required string Filename { get; set; }
+
+    public required string Licence { get; set; }
+
+    public required string Location { get; set; }
+
+    public required string Md5Hash { get; set; }
+
+    public required long Size { get; set; }
+
+    // TODO : Collect MirrorUrl
+    // public required string MirrorUrl { get; set; }
+
+    public required DateTimeOffset Updated { get; set; }
+
+    public required string Uploader { get; set; }
+
+    public required string Url { get; set; }
+
+    public override string ToString() =>
+        $"{nameof(ModDbPageMetadata)} {{ "
+        + $"{nameof(Added)} = {Added:o}, "
+        + $"{nameof(Category)} = {Category}, "
+        + $"{nameof(Credits)} = {Credits}, "
+        + $"{nameof(Downloads)} = {Downloads}, "
+        + $"{nameof(Filename)} = {Filename}, "
+        + $"{nameof(Licence)} = {Licence}, "
+        + $"{nameof(Location)} = {Location}, "
+        + $"{nameof(Md5Hash)} = {Md5Hash}, "
+        + $"{nameof(Size)} = {Size}, "
+        + $"{nameof(Updated)} = {Updated:o}, "
+        + $"{nameof(Uploader)} = {Uploader}, "
+        + $"{nameof(Url)} = {Url} "
+        + "}";
+}

--- a/Stalker.Gamma/Models/ModDbRecord.cs
+++ b/Stalker.Gamma/Models/ModDbRecord.cs
@@ -42,7 +42,7 @@ public class ModDbRecord(
                     && await HashUtils.HashFile(
                         DownloadPath,
                         HashAlgorithmName.MD5,
-                        pct => OnProgress("Check MD5", pct),
+                        pct => OnProgress(GammaProgressType.CheckMd5, pct),
                         cancellationToken
                     ) != Md5
                 || !Path.Exists(DownloadPath)
@@ -51,7 +51,7 @@ public class ModDbRecord(
                 await _modDbUtility.GetModDbLinkCurl(
                     Url,
                     DownloadPath,
-                    pct => OnProgress("Download", pct),
+                    pct => OnProgress(GammaProgressType.Download, pct),
                     cancellationToken: cancellationToken
                 );
                 Downloaded = true;
@@ -86,7 +86,7 @@ public class ModDbRecord(
             await _archiveUtility.ExtractAsync(
                 DownloadPath,
                 ExtractPath,
-                pct => OnProgress("Extract", pct),
+                pct => OnProgress(GammaProgressType.Extract, pct),
                 ct: cancellationToken
             );
 
@@ -124,10 +124,13 @@ public class ModDbRecord(
             Instructions: {string.Join(", ", Instructions)}
             """;
 
-    private void OnProgress(string operation, double pct) =>
+    private void OnProgress(GammaProgressType operation, double pct) =>
         _gammaProgress.OnProgressChanged(ProgFunc(operation, pct));
 
-    private GammaProgress.GammaInstallProgressEventArgs ProgFunc(string operation, double pct) =>
+    private GammaProgress.GammaInstallProgressEventArgs ProgFunc(
+        GammaProgressType operation,
+        double pct
+    ) =>
         new()
         {
             Name = Name,

--- a/Stalker.Gamma/Models/ModDbRecordGetMetadata.cs
+++ b/Stalker.Gamma/Models/ModDbRecordGetMetadata.cs
@@ -1,0 +1,148 @@
+using System.Security.Cryptography;
+using Stalker.Gamma.GammaInstallerServices;
+using Stalker.Gamma.Utilities;
+
+namespace Stalker.Gamma.Models;
+
+public class ModDbRecordGetMetadata(
+    string name,
+    string startLink,
+    List<string> instructions,
+    string outputDirName,
+    string gammaDir,
+    ArchiveUtility archiveUtility,
+    GammaProgress gammaProgress,
+    ModDbUtility modDbUtility,
+    GetCanonicalLinkFromModDbStartLink getCanonicalLinkFromModDbStartLink,
+    GetModDbAddonMetadata getModDbAddonMetadata
+) : IDownloadableRecord
+{
+    public string Name { get; } = name;
+    public string ArchiveName { get; set; } = null!;
+    public string DownloadPath => Path.Join(_gammaDir, "downloads", ArchiveName);
+    public string ExtractPath => Path.Join(_gammaDir, "mods", OutputDirName);
+    public string StartLink { get; set; } = startLink;
+    public string NiceUrl { get; set; } = null!;
+    private List<string> Instructions { get; } = instructions;
+    private string OutputDirName { get; } = outputDirName;
+    public string Url => StartLink;
+    public string Md5 { get; set; } = null!;
+
+    public async Task DownloadAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await GetModDbAddonMetadataAsync(cancellationToken);
+            if (
+                Path.Exists(DownloadPath)
+                    && !string.IsNullOrWhiteSpace(Md5)
+                    && await HashUtils.HashFile(
+                        DownloadPath,
+                        HashAlgorithmName.MD5,
+                        pct => OnProgress(GammaProgressType.CheckMd5, pct),
+                        cancellationToken
+                    ) != Md5
+                || !Path.Exists(DownloadPath)
+            )
+            {
+                await _modDbUtility.GetModDbLinkCurl(
+                    Url,
+                    DownloadPath,
+                    pct => OnProgress(GammaProgressType.Download, pct),
+                    cancellationToken: cancellationToken
+                );
+                Downloaded = true;
+            }
+        }
+        catch (Exception e) when (e is not ModDbBotDetectedException)
+        {
+            throw new ModDbRecordException(
+                $"""
+                Error downloading ModDb record
+                {ToString()}
+                Exception Message: {e.Message}
+                """,
+                e
+            );
+        }
+    }
+
+    public async Task ExtractAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            // Delete what was previously extracted
+            if (Directory.Exists(ExtractPath))
+            {
+                DirUtils.NormalizePermissions(ExtractPath);
+                DirUtils.RecursivelyDeleteDirectory(ExtractPath, doNotMatch: []);
+            }
+
+            Directory.CreateDirectory(ExtractPath);
+
+            await _archiveUtility.ExtractAsync(
+                DownloadPath,
+                ExtractPath,
+                pct => OnProgress(GammaProgressType.Extract, pct),
+                ct: cancellationToken
+            );
+
+            ProcessInstructions.Process(ExtractPath, Instructions, cancellationToken);
+
+            CleanExtractPath.Clean(ExtractPath);
+
+            WriteAddonMetaIni.Write(ExtractPath, ArchiveName, NiceUrl);
+        }
+        catch (Exception e)
+        {
+            throw new ModDbRecordException(
+                $"""
+                Error extracting ModDb record
+                {ToString()}
+                Exception Message: {e.Message}
+                """,
+                e
+            );
+        }
+    }
+
+    private async Task GetModDbAddonMetadataAsync(CancellationToken cancellationToken)
+    {
+        var canonicalLink = await _getCanonicalLinkFromModDbStartLink.GetCanonicalLinkAsync(
+            StartLink,
+            cancellationToken
+        );
+        var metadata = await _getModDbAddonMetadata.GetAsync(canonicalLink, cancellationToken);
+        ArchiveName = metadata.Filename;
+        Md5 = metadata.Md5Hash;
+        NiceUrl = canonicalLink;
+    }
+
+    public bool Downloaded { get; set; }
+
+    private void OnProgress(GammaProgressType operation, double pct) =>
+        _gammaProgress.OnProgressChanged(ProgFunc(operation, pct));
+
+    private GammaProgress.GammaInstallProgressEventArgs ProgFunc(
+        GammaProgressType operation,
+        double pct
+    ) =>
+        new()
+        {
+            Name = Name,
+            ProgressType = operation,
+            Progress = pct,
+            Url = Url,
+            ArchiveName = ArchiveName,
+            DownloadPath = DownloadPath,
+            ExtractPath = ExtractPath,
+        };
+
+    private readonly GammaProgress _gammaProgress = gammaProgress;
+    private readonly string _gammaDir = gammaDir;
+    private readonly ArchiveUtility _archiveUtility = archiveUtility;
+    private readonly ModDbUtility _modDbUtility = modDbUtility;
+    private readonly GetCanonicalLinkFromModDbStartLink _getCanonicalLinkFromModDbStartLink =
+        getCanonicalLinkFromModDbStartLink;
+    private readonly GetModDbAddonMetadata _getModDbAddonMetadata = getModDbAddonMetadata;
+}

--- a/Stalker.Gamma/Models/ModDbRecordGetMetadataGroup.cs
+++ b/Stalker.Gamma/Models/ModDbRecordGetMetadataGroup.cs
@@ -1,0 +1,35 @@
+using Stalker.Gamma.GammaInstallerServices;
+
+namespace Stalker.Gamma.Models;
+
+public class ModDbRecordGetMetadataGroup(
+    GammaProgress gammaProgress,
+    IList<ModDbRecordGetMetadata> modDbRecords
+) : IDownloadableRecord
+{
+    public string Name => _modDbRecords.First().Name;
+    public string ArchiveName => _modDbRecords.First().ArchiveName;
+    public string DownloadPath => _modDbRecords.First().DownloadPath;
+    private string StartLink => _modDbRecords.First().StartLink;
+    private string Md5 => _modDbRecords.First().Md5;
+
+    public virtual async Task DownloadAsync(CancellationToken cancellationToken) =>
+        await _modDbRecords.First().DownloadAsync(cancellationToken);
+
+    public virtual async Task ExtractAsync(CancellationToken cancellationToken)
+    {
+        foreach (var modDbRecord in _modDbRecords)
+        {
+            modDbRecord.ArchiveName = ArchiveName;
+            modDbRecord.Md5 = Md5;
+            modDbRecord.StartLink = StartLink;
+
+            await modDbRecord.ExtractAsync(cancellationToken);
+        }
+        _gammaProgress.IncrementCompletedMods();
+    }
+
+    public bool Downloaded => _modDbRecords.Any(x => x.Downloaded);
+    private readonly GammaProgress _gammaProgress = gammaProgress;
+    private readonly IList<ModDbRecordGetMetadata> _modDbRecords = modDbRecords;
+}

--- a/Stalker.Gamma/Models/SkipExtractWhenNotDownloadedRecord.cs
+++ b/Stalker.Gamma/Models/SkipExtractWhenNotDownloadedRecord.cs
@@ -31,7 +31,7 @@ public class SkipExtractWhenNotDownloadedRecord(
                 new GammaProgress.GammaInstallProgressEventArgs
                 {
                     Name = Name,
-                    ProgressType = "Skipped",
+                    ProgressType = GammaProgressType.Skipped,
                     Progress = 1,
                     Url = "",
                     ArchiveName = ArchiveName,

--- a/Stalker.Gamma/Models/SkippedRecord.cs
+++ b/Stalker.Gamma/Models/SkippedRecord.cs
@@ -13,23 +13,26 @@ public class SkippedRecord(GammaProgress gammaProgress, IDownloadableRecord reco
 
     public Task DownloadAsync(CancellationToken cancellationToken)
     {
-        OnProgress("Skipped", 1);
+        OnProgress(GammaProgressType.Skipped, 1);
         return Task.CompletedTask;
     }
 
     public Task ExtractAsync(CancellationToken cancellationToken)
     {
-        OnProgress("Skipped", 1);
+        OnProgress(GammaProgressType.Skipped, 1);
         _gammaProgress.IncrementCompletedMods();
         return Task.CompletedTask;
     }
 
     public bool Downloaded { get; }
 
-    private void OnProgress(string operation, double pct) =>
+    private void OnProgress(GammaProgressType operation, double pct) =>
         _gammaProgress.OnProgressChanged(ProgFunc(operation, pct));
 
-    private GammaProgress.GammaInstallProgressEventArgs ProgFunc(string operation, double pct) =>
+    private GammaProgress.GammaInstallProgressEventArgs ProgFunc(
+        GammaProgressType operation,
+        double pct
+    ) =>
         new()
         {
             Name = Name,

--- a/Stalker.Gamma/Stalker.Gamma.csproj
+++ b/Stalker.Gamma/Stalker.Gamma.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CliWrap" Version="3.10.0" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />

--- a/Stalker.Gamma/Utilities/CurlUtility.cs
+++ b/Stalker.Gamma/Utilities/CurlUtility.cs
@@ -56,7 +56,20 @@ public partial class CurlUtility(StalkerGammaSettings settings)
                         .Add(Path.Join(AppContext.BaseDirectory, "resources", "cacert.pem"))
                         .AddImpersonation()
                 )
-                .WithStandardOutputPipe(PipeTarget.ToStringBuilder(stdOut))
+                .WithStandardOutputPipe(
+                    PipeTarget.Merge(
+                        PipeTarget.ToStringBuilder(stdOut),
+                        PipeTarget.ToDelegate(line =>
+                        {
+                            if (line.Contains("It appears you are a bot"))
+                            {
+                                throw new ModDbBotDetectedException(
+                                    "ModDb temporarily blocked you. Try again in 1 hour."
+                                );
+                            }
+                        })
+                    )
+                )
                 .WithStandardErrorPipe(
                     PipeTarget.Merge(
                         PipeTarget.ToStringBuilder(stdErr),
@@ -82,7 +95,7 @@ public partial class CurlUtility(StalkerGammaSettings settings)
                 .WithWorkingDirectory(workingDir ?? "")
                 .ExecuteAsync(cancellationToken);
         }
-        catch (Exception e)
+        catch (Exception e) when (e is not ModDbBotDetectedException)
         {
             throw new CurlServiceException(
                 $"""
@@ -111,6 +124,8 @@ public partial class CurlUtility(StalkerGammaSettings settings)
     [GeneratedRegex(@"(\d+([\.,]\d+)?)\s*%", RegexOptions.Compiled)]
     private partial Regex ProgressRx();
 }
+
+public class ModDbBotDetectedException(string msg) : Exception(msg);
 
 public class CurlServiceException(string message, Exception innerException)
     : Exception(message, innerException);

--- a/stalker-gamma-cli/Commands/Anomaly.cs
+++ b/stalker-gamma-cli/Commands/Anomaly.cs
@@ -322,7 +322,7 @@ public class AnomalyInstallCmd(
         _logger.Information(
             Informational,
             e.Name[..Math.Min(e.Name.Length, 35)].PadRight(40),
-            e.ProgressType.PadRight(10),
+            e.ProgressType.GetHumanReadableString().PadRight(10),
             $"{e.Progress:P2}".PadRight(8),
             $"[{e.Complete}/{e.Total}]"
         );
@@ -331,7 +331,7 @@ public class AnomalyInstallCmd(
         _logger.Information(
             Verbose,
             e.Name[..Math.Min(e.Name.Length, 35)].PadRight(40),
-            e.ProgressType.PadRight(10),
+            e.ProgressType.GetHumanReadableString().PadRight(10),
             $"{e.Progress:P2}".PadRight(8),
             $"[{e.Complete}/{e.Total}]",
             e.Url

--- a/stalker-gamma-cli/Commands/Config.cs
+++ b/stalker-gamma-cli/Commands/Config.cs
@@ -86,7 +86,7 @@ public class Config(ILogger logger, CliSettings cliSettings, UtilitiesReady util
     /// <param name="mo2Profile">The ModOrganizer profile to operate on</param>
     /// <param name="modPackMakerUrl">The modpack_maker_list definition url</param>
     /// <param name="modListUrl">The modlist definition url</param>
-    /// <param name="downloadThreads"></param>
+    /// <param name="downloadThreads">The number of threads that can download an extract at the same time</param>
     public async Task Create(
         string anomaly,
         string gamma,
@@ -96,7 +96,7 @@ public class Config(ILogger logger, CliSettings cliSettings, UtilitiesReady util
         string modPackMakerUrl = "https://stalker-gamma.com/api/list",
         string modListUrl =
             "https://raw.githubusercontent.com/Grokitach/Stalker_GAMMA/refs/heads/main/G.A.M.M.A/modpack_data/modlist.txt",
-        [Range(1, 6)] int downloadThreads = 2
+        [Range(1, 20)] int downloadThreads = 2
     )
     {
         if (!utilitiesReady.IsReady)

--- a/stalker-gamma-cli/Commands/FullInstall.cs
+++ b/stalker-gamma-cli/Commands/FullInstall.cs
@@ -56,7 +56,7 @@ public class FullInstallCmd(
         bool offline = false,
         string? modPackMakerPath = null,
         string? modListPath = null,
-        [Range(1, 6)] int? downloadThreads = null,
+        [Range(1, 20)] int? downloadThreads = null,
         [Hidden] bool debug = false,
         [Hidden] string? mo2Version = null,
         [Hidden] long progressUpdateIntervalMs = 250,
@@ -132,8 +132,7 @@ public class FullInstallCmd(
         catch (Exception e)
         {
             progressLoggingService.WriteToLogFile();
-            _logger.Error(e, "Install failed");
-            throw;
+            _logger.Error(e, "Install failed! {ExceptionMessage}", e.Message);
         }
         finally
         {
@@ -271,7 +270,7 @@ public class FullInstallCmd(
             Informational,
             DateTimeOffset.Now.ToString("HH:mm:ss"),
             e.Name[..Math.Min(e.Name.Length, 35)].PadRight(40),
-            e.ProgressType.PadRight(10),
+            e.ProgressType.GetHumanReadableString().PadRight(10),
             $"{e.Progress:P2}".PadRight(8),
             $"[{e.Complete}/{e.Total}]"
         );
@@ -280,7 +279,7 @@ public class FullInstallCmd(
         _logger.Information(
             Verbose,
             e.Name[..Math.Min(e.Name.Length, 35)].PadRight(40),
-            e.ProgressType.PadRight(10),
+            e.ProgressType.GetHumanReadableString().PadRight(10),
             $"{e.Progress:P2}".PadRight(8),
             $"[{e.Complete}/{e.Total}]",
             e.Url

--- a/stalker-gamma-cli/Commands/Update.cs
+++ b/stalker-gamma-cli/Commands/Update.cs
@@ -278,7 +278,7 @@ public class UpdateCmds(
         _logger.Information(
             Informational,
             e.Name[..Math.Min(e.Name.Length, 35)].PadRight(40),
-            e.ProgressType.PadRight(10),
+            e.ProgressType.GetHumanReadableString().PadRight(10),
             $"{e.Progress:P2}".PadRight(8),
             $"[{e.Complete}/{e.Total}]"
         );
@@ -287,7 +287,7 @@ public class UpdateCmds(
         _logger.Information(
             Verbose,
             e.Name[..Math.Min(e.Name.Length, 35)].PadRight(40),
-            e.ProgressType.PadRight(10),
+            e.ProgressType.GetHumanReadableString().PadRight(10),
             $"{e.Progress:P2}".PadRight(8),
             $"[{e.Complete}/{e.Total}]",
             e.Url

--- a/stalker-gamma-cli/Program.cs
+++ b/stalker-gamma-cli/Program.cs
@@ -40,7 +40,7 @@ public static class Program
             )
             .WriteTo.Console(
                 restrictedToMinimumLevel: LogEventLevel.Information,
-                outputTemplate: "{Message:lj}{NewLine}{Exception}",
+                outputTemplate: "{Message:lj}{NewLine}",
                 theme: ConsoleTheme.None
             )
             .CreateLogger();

--- a/stalker-gamma-cli/Services/ProgressLoggingService.cs
+++ b/stalker-gamma-cli/Services/ProgressLoggingService.cs
@@ -90,7 +90,7 @@ public class ProgressLoggingService(ILogger logger)
         AddProgressEvent(
             new LogFileRecord
             {
-                Operation = e.ProgressType,
+                Operation = e.ProgressType.GetHumanReadableString(),
                 ArchiveName = e.Name,
                 Url = e.Url,
                 DownloadPath = e.DownloadPath,


### PR DESCRIPTION
## What's New

- add the capability to retrieve moddb addon metadata instead of stalker-gamma api
- up the max download threads to 20 for fun
- simplify log message output for the cli
- up modorganizer version from 2.4.4 -> 2.5.2

## ModDb Addon Metadata Retrieval

- not enabled by default
- performing a `full-install` 2X will get you temporarily blocked as a bot by ModDb. This is the exception you would see:

  ```
  [08:33:34] Stalker Anomaly                          | Extract    | 98.00%   | [0/385]
  [08:33:36] Stalker Anomaly                          | Extract    | 98.00%   | [0/385]
  [08:33:37] Stalker Anomaly                          | Extract    | 98.00%   | [0/385]
  Install failed! ModDb temporarily blocked you. Try again in 1 hour.
  ```

- To enable for a new config:

  ```bash
  stalker-gamma config create \
  --anomaly gamma/anomaly \
  --gamma gamma/gamma \
  --cache gamma/cache \
  --mod-pack-maker-url "https://raw.githubusercontent.com/Grokitach/Stalker_GAMMA/refs/heads/main/G.A.M.M.A/modpack_data/modpack_maker_list.txt"
  ```

- To enable for an existing config:

  ```bash
  stalker-gamma config set ModPackMakerUrl "https://raw.githubusercontent.com/Grokitach/Stalker_GAMMA/refs/heads/main/G.A.M.M.A/modpack_data/modpack_maker_list.txt"
  ```

## Notes

- it doesn't seem to matter how quickly you make requests to ModDb as long as you stay under a threshold before you get temporarily blocked. it seems to block based on a total number of requests over a period like an hour
- meaning something like 100 requests over a few minutes won't trigger bot detection, but something like 300 requests over an hour gets you marked as a bot