### PR TITLE
Drop cliwrap

### DIFF
--- a/Stalker.Gamma/GammaInstallerServices/GetCanonicalLinkFromModDbStartLink.cs
+++ b/Stalker.Gamma/GammaInstallerServices/GetCanonicalLinkFromModDbStartLink.cs
@@ -10,13 +10,14 @@ public class GetCanonicalLinkFromModDbStartLink(CurlUtility curlUtility)
         CancellationToken ct = default
     )
     {
+        string? htmlContent = null;
         try
         {
-            var htmlContent = await _curlUtility.GetStringAsync(modDbStartLink, ct);
+            htmlContent = await _curlUtility.GetStringAsync(modDbStartLink, ct);
             var htmlDoc = new HtmlDocument();
             htmlDoc.LoadHtml(htmlContent);
             var linkNode = htmlDoc.DocumentNode.SelectSingleNode("//link[@rel='canonical']");
-            var canonicalLink = linkNode?.GetAttributeValue("href", string.Empty);
+            var canonicalLink = linkNode.GetAttributeValue("href", string.Empty);
             return string.IsNullOrWhiteSpace(canonicalLink)
                 ? throw new CanonicalLinkNotFoundException(modDbStartLink)
                 : canonicalLink;
@@ -25,7 +26,12 @@ public class GetCanonicalLinkFromModDbStartLink(CurlUtility curlUtility)
             when (e is not CanonicalLinkNotFoundException and not ModDbBotDetectedException)
         {
             throw new GetCanonicalLinkFromModDbStartLinkException(
-                $"Error retrieving canonical link from: {modDbStartLink}",
+                $"""
+                Error retrieving canonical link from
+                ModDbStartLink: {modDbStartLink}
+                Exception Message: {e.Message}
+                HTML Content: {htmlContent}
+                """,
                 e
             );
         }

--- a/Stalker.Gamma/Stalker.Gamma.csproj
+++ b/Stalker.Gamma/Stalker.Gamma.csproj
@@ -12,11 +12,11 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CliWrap" Version="3.10.0" />
+    <PackageReference Include="CliWrap" Version="3.10.1" />
     <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.6" />
     <PackageReference Include="WindowsShortcutFactory" Version="1.2.0" />
   </ItemGroup>
 </Project>

--- a/Stalker.Gamma/Stalker.Gamma.csproj
+++ b/Stalker.Gamma/Stalker.Gamma.csproj
@@ -12,7 +12,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CliWrap" Version="3.10.1" />
     <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />

--- a/Stalker.Gamma/Utilities/CurlUtility.cs
+++ b/Stalker.Gamma/Utilities/CurlUtility.cs
@@ -1,9 +1,6 @@
 using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
-using CliWrap;
-using CliWrap.Buffered;
-using CliWrap.Builders;
 using Stalker.Gamma.Models;
 
 namespace Stalker.Gamma.Utilities;
@@ -45,58 +42,42 @@ public partial class CurlUtility(StalkerGammaSettings settings)
     {
         var stdOut = new StringBuilder();
         var stdErr = new StringBuilder();
-        try
-        {
-            args.AddRange(
-                "--cacert",
-                Path.Join(AppContext.BaseDirectory, "resources", "cacert.pem")
-            );
-            args.AddImpersonation();
-            var result = await RunProcessUtility.RunProcessAsync(
-                PathToCurlImpersonate,
-                args,
-                onStdout: line =>
+        args.AddRange("--cacert", Path.Join(AppContext.BaseDirectory, "resources", "cacert.pem"));
+        args.AddImpersonation();
+        var exitCode = await RunProcessUtility.RunProcessAsync(
+            PathToCurlImpersonate,
+            args,
+            onStdout: line =>
+            {
+                if (line.Contains("It appears you are a bot"))
                 {
-                    if (line.Contains("It appears you are a bot"))
-                    {
-                        throw new ModDbBotDetectedException(
-                            "ModDb temporarily blocked you. Try again in 1 hour."
-                        );
-                    }
-                    stdOut.AppendLine(line);
-                },
-                onStderr: line =>
-                {
-                    var match = ProgressRx().Match(line);
-                    if (
-                        onProgress is not null
-                        && match.Success
-                        && double.TryParse(
-                            ProgressRx().Match(line).Groups[1].Value,
-                            provider: CultureInfo.InvariantCulture,
-                            out var parsed
-                        )
+                    throw new ModDbBotDetectedException(
+                        "ModDb temporarily blocked you. Try again in 1 hour."
+                    );
+                }
+                stdOut.AppendLine(line);
+            },
+            onStderr: line =>
+            {
+                var match = ProgressRx().Match(line);
+                if (
+                    onProgress is not null
+                    && match.Success
+                    && double.TryParse(
+                        ProgressRx().Match(line).Groups[1].Value,
+                        provider: CultureInfo.InvariantCulture,
+                        out var parsed
                     )
-                    {
-                        onProgress(parsed / 100);
-                    }
-                    stdErr.AppendLine(line);
-                },
-                workingDir,
-                cancellationToken
-            );
-            return new StdOutStdErrOutput(stdOut.ToString(), stdErr.ToString());
-        }
-        catch (Exception e)
-            when (e is OperationCanceledException or TaskCanceledException
-                && cancellationToken.IsCancellationRequested
-                && stdOut.Length > 0
-            )
-        {
-            // weird case where the output is there, but the task won't complete on its own.
-            return new StdOutStdErrOutput(stdOut.ToString(), stdErr.ToString());
-        }
-        catch (Exception e) when (e is not ModDbBotDetectedException)
+                )
+                {
+                    onProgress(parsed / 100);
+                }
+                stdErr.AppendLine(line);
+            },
+            workingDir,
+            ct: cancellationToken
+        );
+        if (exitCode != 0)
         {
             throw new CurlServiceException(
                 $"""
@@ -104,11 +85,11 @@ public partial class CurlUtility(StalkerGammaSettings settings)
                 {string.Join(' ', args)}
                 StdOut: {stdOut}
                 StdErr: {stdErr}
-                Exception Message: {e.Message}
-                """,
-                e
+                Exit Code: {exitCode}
+                """
             );
         }
+        return new StdOutStdErrOutput(stdOut.ToString(), stdErr.ToString());
     }
 
     private string PathToCurlImpersonate => settings.PathToCurl;
@@ -126,8 +107,14 @@ public partial class CurlUtility(StalkerGammaSettings settings)
 
 public class ModDbBotDetectedException(string msg) : Exception(msg);
 
-public class CurlServiceException(string message, Exception innerException)
-    : Exception(message, innerException);
+public class CurlServiceException : Exception
+{
+    public CurlServiceException(string message)
+        : base(message) { }
+
+    public CurlServiceException(string message, Exception innerException)
+        : base(message, innerException) { }
+}
 
 internal static class ArgumentsBuilderExtensions
 {

--- a/Stalker.Gamma/Utilities/CurlUtility.cs
+++ b/Stalker.Gamma/Utilities/CurlUtility.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
 using CliWrap;
+using CliWrap.Buffered;
 using CliWrap.Builders;
 using Stalker.Gamma.Models;
 
@@ -36,64 +37,64 @@ public partial class CurlUtility(StalkerGammaSettings settings)
         ).StdOut;
 
     private async Task<StdOutStdErrOutput> ExecuteCurlCmdAsync(
-        string[] args,
+        List<string> args,
         Action<double>? onProgress = null,
-        Action<string>? txtProgress = null,
         string? workingDir = null,
         CancellationToken cancellationToken = default
     )
     {
         var stdOut = new StringBuilder();
         var stdErr = new StringBuilder();
-
         try
         {
-            await Cli.Wrap(PathToCurlImpersonate)
-                .WithArguments(argBuilder =>
-                    argBuilder
-                        .Add(args)
-                        .Add("--cacert")
-                        .Add(Path.Join(AppContext.BaseDirectory, "resources", "cacert.pem"))
-                        .AddImpersonation()
-                )
-                .WithStandardOutputPipe(
-                    PipeTarget.Merge(
-                        PipeTarget.ToStringBuilder(stdOut),
-                        PipeTarget.ToDelegate(line =>
-                        {
-                            if (line.Contains("It appears you are a bot"))
-                            {
-                                throw new ModDbBotDetectedException(
-                                    "ModDb temporarily blocked you. Try again in 1 hour."
-                                );
-                            }
-                        })
+            args.AddRange(
+                "--cacert",
+                Path.Join(AppContext.BaseDirectory, "resources", "cacert.pem")
+            );
+            args.AddImpersonation();
+            var result = await RunProcessUtility.RunProcessAsync(
+                PathToCurlImpersonate,
+                args,
+                onStdout: line =>
+                {
+                    if (line.Contains("It appears you are a bot"))
+                    {
+                        throw new ModDbBotDetectedException(
+                            "ModDb temporarily blocked you. Try again in 1 hour."
+                        );
+                    }
+                    stdOut.AppendLine(line);
+                },
+                onStderr: line =>
+                {
+                    var match = ProgressRx().Match(line);
+                    if (
+                        onProgress is not null
+                        && match.Success
+                        && double.TryParse(
+                            ProgressRx().Match(line).Groups[1].Value,
+                            provider: CultureInfo.InvariantCulture,
+                            out var parsed
+                        )
                     )
-                )
-                .WithStandardErrorPipe(
-                    PipeTarget.Merge(
-                        PipeTarget.ToStringBuilder(stdErr),
-                        PipeTarget.ToDelegate(line =>
-                        {
-                            txtProgress?.Invoke(line);
-                            var match = ProgressRx().Match(line);
-                            if (
-                                onProgress is not null
-                                && match.Success
-                                && double.TryParse(
-                                    ProgressRx().Match(line).Groups[1].Value,
-                                    provider: CultureInfo.InvariantCulture,
-                                    out var parsed
-                                )
-                            )
-                            {
-                                onProgress(parsed / 100);
-                            }
-                        })
-                    )
-                )
-                .WithWorkingDirectory(workingDir ?? "")
-                .ExecuteAsync(cancellationToken);
+                    {
+                        onProgress(parsed / 100);
+                    }
+                    stdErr.AppendLine(line);
+                },
+                workingDir,
+                cancellationToken
+            );
+            return new StdOutStdErrOutput(stdOut.ToString(), stdErr.ToString());
+        }
+        catch (Exception e)
+            when (e is OperationCanceledException or TaskCanceledException
+                && cancellationToken.IsCancellationRequested
+                && stdOut.Length > 0
+            )
+        {
+            // weird case where the output is there, but the task won't complete on its own.
+            return new StdOutStdErrOutput(stdOut.ToString(), stdErr.ToString());
         }
         catch (Exception e) when (e is not ModDbBotDetectedException)
         {
@@ -103,13 +104,11 @@ public partial class CurlUtility(StalkerGammaSettings settings)
                 {string.Join(' ', args)}
                 StdOut: {stdOut}
                 StdErr: {stdErr}
-                Exception: {e}
+                Exception Message: {e.Message}
                 """,
                 e
             );
         }
-
-        return new StdOutStdErrOutput(stdOut.ToString(), stdErr.ToString());
     }
 
     private string PathToCurlImpersonate => settings.PathToCurl;
@@ -145,6 +144,9 @@ internal static class ArgumentsBuilderExtensions
         Random.Shared.Next(Impersonations.Count)
     );
 
-    internal static ArgumentsBuilder AddImpersonation(this ArgumentsBuilder argBuilder) =>
-        argBuilder.Add("--compressed").Add("--impersonate").Add(Impersonation);
+    internal static List<string> AddImpersonation(this List<string> argBuilder)
+    {
+        argBuilder.AddRange("--compressed", "--impersonate", Impersonation);
+        return argBuilder;
+    }
 }

--- a/Stalker.Gamma/Utilities/RunProcessUtility.cs
+++ b/Stalker.Gamma/Utilities/RunProcessUtility.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Text;
 
 namespace Stalker.Gamma.Utilities;
 
@@ -10,6 +11,7 @@ public static partial class RunProcessUtility
         Action<string> onStdout,
         Action<string> onStderr,
         string? workingDirectory = null,
+        Encoding? stdOutEncoding = null,
         CancellationToken ct = default
     )
     {
@@ -23,6 +25,7 @@ public static partial class RunProcessUtility
             UseShellExecute = false,
             CreateNoWindow = true,
             WorkingDirectory = workingDirectory,
+            StandardOutputEncoding = stdOutEncoding,
         };
         process.EnableRaisingEvents = true;
 

--- a/Stalker.Gamma/Utilities/RunProcessUtility.cs
+++ b/Stalker.Gamma/Utilities/RunProcessUtility.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System.Buffers;
+using System.Diagnostics;
 using System.Text;
 
 namespace Stalker.Gamma.Utilities;
@@ -47,10 +48,37 @@ public static partial class RunProcessUtility
         CancellationToken ct
     )
     {
-        while (await reader.ReadLineAsync(ct) is { } line)
+        var sb = new StringBuilder();
+        var buffer = ArrayPool<char>.Shared.Rent(4096);
+        try
         {
-            ct.ThrowIfCancellationRequested();
-            onLine(line);
+            int read;
+            while ((read = await reader.ReadAsync(buffer, 0, buffer.Length)) > 0)
+            {
+                ct.ThrowIfCancellationRequested();
+                for (var i = 0; i < read; i++)
+                {
+                    // 7z updates the terminal with \b control characters, se we consider everything in sb as a line
+                    if (buffer[i] == '\n' || buffer[i] == '\r' || buffer[i] == '\b')
+                    {
+                        onLine(sb.ToString());
+                        sb.Clear();
+                    }
+                    else
+                    {
+                        sb.Append(buffer[i]);
+                    }
+                }
+            }
+
+            if (sb.Length > 0)
+            {
+                onLine(sb.ToString());
+            }
+        }
+        finally
+        {
+            ArrayPool<char>.Shared.Return(buffer);
         }
     }
 }

--- a/Stalker.Gamma/Utilities/RunProcessUtility.cs
+++ b/Stalker.Gamma/Utilities/RunProcessUtility.cs
@@ -1,0 +1,53 @@
+﻿using System.Diagnostics;
+
+namespace Stalker.Gamma.Utilities;
+
+public static partial class RunProcessUtility
+{
+    public static async Task<int> RunProcessAsync(
+        string fileName,
+        IEnumerable<string> arguments,
+        Action<string> onStdout,
+        Action<string> onStderr,
+        string? workingDirectory = null,
+        CancellationToken ct = default
+    )
+    {
+        using var process = new Process();
+        process.StartInfo = new ProcessStartInfo
+        {
+            FileName = fileName,
+            Arguments = string.Join(' ', arguments),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = workingDirectory,
+        };
+        process.EnableRaisingEvents = true;
+
+        process.Start();
+
+        // Read both streams concurrently to avoid deadlocks
+        var stdoutTask = ReadStreamAsync(process.StandardOutput, onStdout, ct);
+        var stderrTask = ReadStreamAsync(process.StandardError, onStderr, ct);
+
+        await Task.WhenAll(stdoutTask, stderrTask);
+        await process.WaitForExitAsync(ct);
+
+        return process.ExitCode;
+    }
+
+    private static async Task ReadStreamAsync(
+        StreamReader reader,
+        Action<string> onLine,
+        CancellationToken ct
+    )
+    {
+        while (await reader.ReadLineAsync(ct) is { } line)
+        {
+            ct.ThrowIfCancellationRequested();
+            onLine(line);
+        }
+    }
+}

--- a/Stalker.Gamma/Utilities/SevenZipUtility.cs
+++ b/Stalker.Gamma/Utilities/SevenZipUtility.cs
@@ -1,7 +1,5 @@
 using System.Text;
 using System.Text.RegularExpressions;
-using CliWrap;
-using CliWrap.Builders;
 using Stalker.Gamma.Models;
 
 namespace Stalker.Gamma.Utilities;
@@ -12,7 +10,6 @@ public partial class SevenZipUtility(StalkerGammaSettings settings)
         string archivePath,
         string destinationFolder,
         Action<double>? onProgress = null,
-        Action<string>? txtProgress = null,
         string? workingDirectory = null,
         CancellationToken cancellationToken = default
     )
@@ -23,9 +20,8 @@ public partial class SevenZipUtility(StalkerGammaSettings settings)
         }
 
         return await ExecuteSevenZipCmdAsync(
-            ["x", "-y", "-bsp1", archivePath, $"-o{destinationFolder}"],
+            ["x", "-y", "-bsp1", $"\"{archivePath}\"", $"\"-o{destinationFolder}\""],
             onProgress,
-            txtProgress,
             workingDirectory: workingDirectory,
             cancellationToken: cancellationToken
         );
@@ -69,7 +65,6 @@ public partial class SevenZipUtility(StalkerGammaSettings settings)
         return await ExecuteSevenZipCmdAsync(
             args,
             workingDirectory: workDirectory,
-            txtProgress: txtProgress,
             cancellationToken: cancellationToken
         );
     }
@@ -81,7 +76,6 @@ public partial class SevenZipUtility(StalkerGammaSettings settings)
     private async Task<StdOutStdErrOutput> ExecuteSevenZipCmdAsync(
         string[] args,
         Action<double>? onProgress = null,
-        Action<string>? txtProgress = null,
         string? workingDirectory = null,
         CancellationToken cancellationToken = default
     )
@@ -89,61 +83,31 @@ public partial class SevenZipUtility(StalkerGammaSettings settings)
         var stdOut = new StringBuilder();
         var stdErr = new StringBuilder();
 
-        try
-        {
-            await Cli.Wrap(PathTo7Z)
-                .WithArguments(argBuilder => AppendArgument(args, argBuilder))
-                .WithStandardErrorPipe(PipeTarget.ToStringBuilder(stdErr))
-                .WithStandardOutputPipe(
-                    PipeTarget.Merge(
-                        PipeTarget.ToStringBuilder(stdOut),
-                        PipeTarget.Create(
-                            async (origin, ct) =>
-                            {
-                                // Buffer must be bigger than the process's stdout/stderr buffer
-                                const int bufferSize = 1024;
-
-                                using var reader = new StreamReader(
-                                    origin,
-                                    Console.OutputEncoding,
-                                    false,
-                                    bufferSize,
-                                    true
-                                );
-                                var buffer = new char[bufferSize];
-
-                                int charsRead;
-                                while (
-                                    (charsRead = await reader.ReadAsync(buffer, 0, buffer.Length))
-                                    > 0
-                                )
-                                {
-                                    ct.ThrowIfCancellationRequested();
-
-                                    var data = new string(buffer, 0, charsRead);
-
-                                    // Do something with data here
-                                    if (onProgress is null)
-                                    {
-                                        return;
-                                    }
-                                    var matches = ProgressRx().Matches(data).ToList();
-                                    if (matches.Count > 0)
-                                    {
-                                        foreach (var m in matches)
-                                        {
-                                            onProgress(double.Parse(m.Groups[1].Value) / 100);
-                                        }
-                                    }
-                                }
-                            }
-                        )
-                    )
-                )
-                .WithWorkingDirectory(workingDirectory ?? "")
-                .ExecuteAsync(cancellationToken);
-        }
-        catch (Exception e)
+        var exitCode = await RunProcessUtility.RunProcessAsync(
+            PathTo7Z,
+            args,
+            onStdout: line =>
+            {
+                stdOut.AppendLine(line);
+                if (onProgress is null)
+                {
+                    return;
+                }
+                var matches = ProgressRx().Matches(line).ToList();
+                if (matches.Count > 0)
+                {
+                    foreach (var m in matches)
+                    {
+                        onProgress(double.Parse(m.Groups[1].Value) / 100);
+                    }
+                }
+            },
+            onStderr: line => stdErr.AppendLine(line),
+            workingDirectory,
+            stdOutEncoding: Console.OutputEncoding,
+            ct: cancellationToken
+        );
+        if (exitCode != 0)
         {
             throw new SevenZipUtilityException(
                 $"""
@@ -151,9 +115,8 @@ public partial class SevenZipUtility(StalkerGammaSettings settings)
                 {string.Join(' ', args)}
                 StdOut: {stdOut}
                 StdErr: {stdErr}
-                Exception: {e}
-                """,
-                e
+                Exit Code: {exitCode}
+                """
             );
         }
 
@@ -163,19 +126,10 @@ public partial class SevenZipUtility(StalkerGammaSettings settings)
         return new StdOutStdErrOutput(stdOut.ToString(), stdErr.ToString());
     }
 
-    private void AppendArgument(string[] args, ArgumentsBuilder argBuilder)
-    {
-        foreach (var arg in args)
-        {
-            argBuilder.Add(arg);
-        }
-    }
-
     private string PathTo7Z => settings.PathTo7Z;
 
     [GeneratedRegex(@"(\d+(\.\d+)?)\s*%", RegexOptions.Compiled)]
     private partial Regex ProgressRx();
 }
 
-public class SevenZipUtilityException(string msg, Exception innerException)
-    : Exception(msg, innerException);
+public class SevenZipUtilityException(string msg) : Exception(msg);

--- a/Stalker.Gamma/Utilities/TarUtility.cs
+++ b/Stalker.Gamma/Utilities/TarUtility.cs
@@ -1,6 +1,4 @@
 using System.Text;
-using CliWrap;
-using CliWrap.Builders;
 using Stalker.Gamma.Models;
 
 namespace Stalker.Gamma.Utilities;
@@ -36,16 +34,15 @@ public class TarUtility(StalkerGammaSettings settings)
         var stdOut = new StringBuilder();
         var stdErr = new StringBuilder();
 
-        try
-        {
-            await Cli.Wrap(settings.PathToTar)
-                .WithArguments(argBuilder => AppendArgument(args, argBuilder))
-                .WithStandardErrorPipe(PipeTarget.ToStringBuilder(stdErr))
-                .WithStandardOutputPipe(PipeTarget.ToStringBuilder(stdOut))
-                .WithWorkingDirectory(workingDirectory ?? "")
-                .ExecuteAsync(cancellationToken);
-        }
-        catch (Exception e)
+        var exitCode = await RunProcessUtility.RunProcessAsync(
+            settings.PathToTar,
+            args,
+            onStdout: line => stdOut.AppendLine(line),
+            onStderr: line => stdErr.AppendLine(line),
+            workingDirectory ?? "",
+            ct: cancellationToken
+        );
+        if (exitCode != 0)
         {
             if (!stdErr.ToString().Contains("appears to use backslashes as path separators"))
             {
@@ -55,9 +52,8 @@ public class TarUtility(StalkerGammaSettings settings)
                     {string.Join(' ', args)}
                     StdOut: {stdOut}
                     StdErr: {stdErr}
-                    Exception: {e}
-                    """,
-                    e
+                    Exit Code: {exitCode}
+                    """
                 );
             }
         }
@@ -66,21 +62,10 @@ public class TarUtility(StalkerGammaSettings settings)
 
         return new StdOutStdErrOutput(stdOut.ToString(), stdErr.ToString());
     }
-
-    private void AppendArgument(string[] args, ArgumentsBuilder argBuilder)
-    {
-        foreach (var arg in args)
-        {
-            argBuilder.Add(arg);
-        }
-    }
 }
 
 public class TarUtilityException : Exception
 {
     public TarUtilityException(string message)
         : base(message) { }
-
-    public TarUtilityException(string message, Exception innerException)
-        : base(message, innerException) { }
 }

--- a/Stalker.Gamma/Utilities/TarUtility.cs
+++ b/Stalker.Gamma/Utilities/TarUtility.cs
@@ -14,7 +14,7 @@ public class TarUtility(StalkerGammaSettings settings)
     {
         Directory.CreateDirectory(extractDirectory);
         await ExecuteTarCmdAsync(
-            ["-xzvf", archivePath, "-C", extractDirectory],
+            ["-xzvf", $"\"{archivePath}\"", "-C", $"\"{extractDirectory}\""],
             onProgress: onProgress,
             cancellationToken: cancellationToken
         );

--- a/Stalker.Gamma/Utilities/UnzipUtility.cs
+++ b/Stalker.Gamma/Utilities/UnzipUtility.cs
@@ -12,7 +12,7 @@ public class UnzipUtility(StalkerGammaSettings settings)
         CancellationToken ct
     ) =>
         await ExecuteUnzipCmdAsync(
-            ["-o", archivePath, "-d", extractDirectory],
+            ["-o", $"\"{archivePath}\"", "-d", $"\"{extractDirectory}\""],
             onProgress: onProgress,
             cancellationToken: ct
         );

--- a/Stalker.Gamma/Utilities/UnzipUtility.cs
+++ b/Stalker.Gamma/Utilities/UnzipUtility.cs
@@ -1,6 +1,4 @@
 using System.Text;
-using CliWrap;
-using CliWrap.Builders;
 using Stalker.Gamma.Models;
 
 namespace Stalker.Gamma.Utilities;
@@ -33,16 +31,15 @@ public class UnzipUtility(StalkerGammaSettings settings)
         var stdOut = new StringBuilder();
         var stdErr = new StringBuilder();
 
-        try
-        {
-            await Cli.Wrap(settings.PathToUnzip)
-                .WithArguments(argBuilder => AppendArgument(args, argBuilder))
-                .WithStandardErrorPipe(PipeTarget.ToStringBuilder(stdErr))
-                .WithStandardOutputPipe(PipeTarget.ToStringBuilder(stdOut))
-                .WithWorkingDirectory(workingDirectory ?? "")
-                .ExecuteAsync(cancellationToken);
-        }
-        catch (Exception e)
+        var exitCode = await RunProcessUtility.RunProcessAsync(
+            settings.PathToUnzip,
+            args,
+            onStdout: line => stdOut.AppendLine(line),
+            onStderr: line => stdErr.AppendLine(line),
+            workingDirectory,
+            ct: cancellationToken
+        );
+        if (exitCode != 0)
         {
             if (!stdErr.ToString().Contains("appears to use backslashes as path separators"))
             {
@@ -52,9 +49,8 @@ public class UnzipUtility(StalkerGammaSettings settings)
                     {string.Join(' ', args)}
                     StdOut: {stdOut}
                     StdErr: {stdErr}
-                    Exception: {e}
-                    """,
-                    e
+                    Exit Code: {exitCode}
+                    """
                 );
             }
         }
@@ -63,15 +59,6 @@ public class UnzipUtility(StalkerGammaSettings settings)
 
         return new StdOutStdErrOutput(stdOut.ToString(), stdErr.ToString());
     }
-
-    private void AppendArgument(string[] args, ArgumentsBuilder argBuilder)
-    {
-        foreach (var arg in args)
-        {
-            argBuilder.Add(arg);
-        }
-    }
 }
 
-public class UnzipUtilityException(string message, Exception innerException)
-    : Exception(message, innerException);
+public class UnzipUtilityException(string message) : Exception(message);


### PR DESCRIPTION
This PR drops CliWrap from the project and uses Process directly for running external executables. I'm pretty sure CliWrap was the cause of a very long bug where the program would deadlock which would require the user to ctrl+c to escape. I also believe this is the reason my stalker-gamma-clone project deadlocks randomly as well. Maybe I'll get to that one day.

Anyway, this should make installing much more reliable.