### PR TITLE
allow --*repo-branch switches to accept shas

### DIFF
--- a/Stalker.Gamma/Utilities/GitUtility.cs
+++ b/Stalker.Gamma/Utilities/GitUtility.cs
@@ -105,10 +105,10 @@ public partial class GitUtility
         CancellationToken ct = default
     )
     {
+        var branchOrSha = branch is "main" or "dev2" ? $"refs/remotes/origin/{branch}" : branch;
+        var gammaLauncherBranch = $"refs/remotes/Grokitach/{branch}";
         using var repo = new Repository(pathToRepo);
-        var commit =
-            repo.Lookup<Commit>($"refs/remotes/origin/{branch}")
-            ?? repo.Lookup<Commit>($"refs/remotes/Grokitach/{branch}");
+        var commit = repo.Lookup<Commit>(branchOrSha) ?? repo.Lookup<Commit>(gammaLauncherBranch);
         await ExtractTreeAsync(commit.Tree, outputDir, ct: ct, onProgress: onProgress);
     }
 

--- a/stalker-gamma-cli/Commands/Config.cs
+++ b/stalker-gamma-cli/Commands/Config.cs
@@ -88,13 +88,13 @@ public class Config(ILogger logger, CliSettings cliSettings, UtilitiesReady util
     /// <param name="modListUrl">The modlist definition url</param>
     /// <param name="downloadThreads">The number of threads that can download an extract at the same time</param>
     /// <param name="gammaSetupRepoUrl">The gamma_setup repo url</param>
-    /// <param name="gammaSetupRepoBranch">The gamma_setup repo branch</param>
+    /// <param name="gammaSetupRepoBranch">The gamma_setup repo branch or commit sha</param>
     /// <param name="stalkerGammaRepoUrl">The Stalker_GAMMA repo url</param>
-    /// <param name="stalkerGammaRepoBranch">The Stalker_GAMMA repo branch</param>
+    /// <param name="stalkerGammaRepoBranch">The Stalker_GAMMA repo branch or commit sha</param>
     /// <param name="gammaLargeFilesRepoUrl">The gamma_large_files repo url</param>
-    /// <param name="gammaLargeFilesRepoBranch">The gamma_large_files repo branch</param>
+    /// <param name="gammaLargeFilesRepoBranch">The gamma_large_files repo branch or commit sha</param>
     /// <param name="teivazAnomalyGunslingerRepoUrl">The teivaz_anomaly_gunslinger repo url</param>
-    /// <param name="teivazAnomalyGunslingerRepoBranch">The teivaz_anomaly_gunslinger repo branch</param>
+    /// <param name="teivazAnomalyGunslingerRepoBranch">The teivaz_anomaly_gunslinger repo branch or commit sha</param>
     public async Task Create(
         string anomaly,
         string gamma,


### PR DESCRIPTION
Advanced user feature.

You can now reference a branch name or a commit sha to download and extract the associated repo at that ref.

`main` or  an example sha `72ba0baa488c60668294fff7d1dd3b7f1f4839ec`

switches:

- `--gamma-setup-repo-branch <branch or sha>`
- `--stalker-gamma-repo-branch <branch or sha>`
- `--gamma-large-files-repo-branch <branch or sha>`
- `--teivaz-anomaly-gunslinger-repo-branch <branch or sha>`

Note that just because you can retrieve previous git repo versions, you cannot retrieve previous moddb addon versions. So, you may extract a git repo associated with a working GAMMA install, but that GAMMA install may no longer work because of moddb addons have updated. Be aware.