### PR TITLE
Exit code

### DIFF
--- a/stalker-gamma-cli/Commands/Anomaly.cs
+++ b/stalker-gamma-cli/Commands/Anomaly.cs
@@ -37,7 +37,7 @@ public class AnomalyInstallCmd(
     /// <returns>
     /// </returns>
     [Command("install")]
-    public async Task AnomalyInstall(
+    public async Task<int> AnomalyInstall(
         CancellationToken cancellationToken,
         bool verbose = false,
         [Hidden] long progressUpdateIntervalMs = 250
@@ -54,6 +54,8 @@ public class AnomalyInstallCmd(
             );
             Environment.Exit(1);
         }
+
+        var statusCode = 0;
 
         ValidateActiveProfile.Validate(_logger, _cliSettings.ActiveProfile);
         var anomaly = _cliSettings.ActiveProfile!.Anomaly;
@@ -86,10 +88,16 @@ public class AnomalyInstallCmd(
             await anomalyInstaller.ExtractAsync(cancellationToken);
             _logger.Information("Anomaly install complete");
         }
+        catch (Exception e)
+        {
+            _logger.Error(e, "Anomaly install failed! {ExceptionMessage}", e.Message);
+            statusCode = 1;
+        }
         finally
         {
             gammaProgressDisposable.Dispose();
         }
+        return statusCode;
     }
 
     /// <summary>
@@ -99,7 +107,7 @@ public class AnomalyInstallCmd(
     /// A cancellation token that can be used to abort the operation.
     /// </param>
     [Command("check")]
-    public async Task CheckAnomaly(CancellationToken cancellationToken)
+    public async Task<int> CheckAnomaly(CancellationToken cancellationToken)
     {
         if (!utilitiesReady.IsReady)
         {
@@ -112,6 +120,8 @@ public class AnomalyInstallCmd(
             );
             Environment.Exit(1);
         }
+
+        var statusCode = 0;
 
         ValidateActiveProfile.Validate(_logger, _cliSettings.ActiveProfile);
         var anomaly = _cliSettings.ActiveProfile!.Anomaly;
@@ -136,6 +146,8 @@ public class AnomalyInstallCmd(
         var actual = await GetActualHashes(cancellationToken, anomaly);
         var longestPath = checksums.MaxBy(x => x.Path.Length).Path.Length + 5;
         await ValidateChecksums(checksums, actual, longestPath);
+
+        return statusCode;
     }
 
     /// <summary>

--- a/stalker-gamma-cli/Commands/Config.cs
+++ b/stalker-gamma-cli/Commands/Config.cs
@@ -104,7 +104,7 @@ public class Config(ILogger logger, CliSettings cliSettings, UtilitiesReady util
         string modPackMakerUrl = "https://stalker-gamma.com/api/client/v1/mods/list",
         string modListUrl =
             "https://raw.githubusercontent.com/Grokitach/Stalker_GAMMA/refs/heads/main/G.A.M.M.A/modpack_data/modlist.txt",
-        [Range(1, 20)] int downloadThreads = 2,
+        [Range(1, 20)] int downloadThreads = 4,
         string gammaSetupRepoUrl = "https://github.com/Grokitach/gamma_setup",
         string gammaSetupRepoBranch = "main",
         string stalkerGammaRepoUrl = "https://github.com/Grokitach/Stalker_GAMMA",

--- a/stalker-gamma-cli/Commands/FullInstall.cs
+++ b/stalker-gamma-cli/Commands/FullInstall.cs
@@ -41,7 +41,7 @@ public class FullInstallCmd(
     /// <param name="downloadThreads">Override downloadThreads defined in your profile</param>
     /// <param name="debug"></param>
     /// <param name="progressUpdateIntervalMs">How frequently to write progress to the console in milliseconds</param>
-    public async Task FullInstall(
+    public async Task<int> FullInstall(
         CancellationToken cancellationToken,
         bool skipGithubDownloads = false,
         bool skipExtractOnHashMatch = false,
@@ -59,6 +59,7 @@ public class FullInstallCmd(
         [Hidden] long progressUpdateIntervalMs = 250
     )
     {
+        var statusCode = 0;
         LogAndExitOnDependencyError.Check(_utilitiesReady, _logger);
 
         ValidateActiveProfile.Validate(_logger, _cliSettings.ActiveProfile);
@@ -125,6 +126,7 @@ public class FullInstallCmd(
         {
             _progressLoggingService.WriteToLogFile();
             _logger.Error(e, "Install failed! {ExceptionMessage}", e.Message);
+            statusCode = 1;
         }
         finally
         {
@@ -133,6 +135,8 @@ public class FullInstallCmd(
             gammaProgressDisposable.Dispose();
             gammaWriteFileDisposable.Dispose();
         }
+
+        return statusCode;
     }
 
     private static void ValidateOfflineRequirements(

--- a/stalker-gamma-cli/Commands/Update.cs
+++ b/stalker-gamma-cli/Commands/Update.cs
@@ -31,8 +31,9 @@ public class UpdateCmds(
     /// Check for updates
     /// </summary>
     [Command("check")]
-    public async Task CheckUpdates(CancellationToken cancellationToken = default)
+    public async Task<int> CheckUpdates(CancellationToken cancellationToken = default)
     {
+        var statusCode = 0;
         LogAndExitOnDependencyError.Check(utilitiesReady, _logger);
         ValidateActiveProfile.Validate(_logger, _cliSettings.ActiveProfile);
         stalkerGammaSettings.ModpackMakerList = _cliSettings.ActiveProfile!.ModPackMakerUrl;
@@ -127,11 +128,13 @@ public class UpdateCmds(
         {
             progressLoggingService.WriteToLogFile();
             _logger.Error(e, "Update check failed! {ExceptionMessage}", e.Message);
+            statusCode = 1;
         }
         finally
         {
             progressLoggingService.WriteToLogFile();
         }
+        return statusCode;
     }
 
     private async Task<List<ModPackMakerRecordDiff>> GetLocalGitRepoDiffs(
@@ -198,7 +201,7 @@ public class UpdateCmds(
     /// <param name="preserveUserSettings">Preserve user settings (user.ltx)</param>
     /// <param name="preserveMcmSettings">Preserve MCM settings</param>
     /// <param name="progressUpdateIntervalMs"></param>
-    public async Task Apply(
+    public async Task<int> Apply(
         CancellationToken cancellationToken,
         bool verbose = false,
         bool minimal = false,
@@ -207,6 +210,8 @@ public class UpdateCmds(
         [Hidden] long progressUpdateIntervalMs = 250
     )
     {
+        var statusCode = 0;
+
         LogAndExitOnDependencyError.Check(utilitiesReady, _logger);
 
         ValidateActiveProfile.Validate(_logger, _cliSettings.ActiveProfile);
@@ -240,6 +245,7 @@ public class UpdateCmds(
         {
             progressLoggingService.WriteToLogFile();
             _logger.Error(e, "Update failed! {ExceptionMessage}", e.Message);
+            statusCode = 1;
         }
         finally
         {
@@ -247,6 +253,8 @@ public class UpdateCmds(
             gammaWriteFileDisposable.Dispose();
             gammaProgressDisposable.Dispose();
         }
+
+        return statusCode;
     }
 
     private void InitializeSettings(

--- a/stalker-gamma-cli/Program.cs
+++ b/stalker-gamma-cli/Program.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using System.Reflection;
+﻿using System.Reflection;
 using System.Text.Json;
 using ConsoleAppFramework;
 using Microsoft.Extensions.DependencyInjection;


### PR DESCRIPTION
Add exit codes to full-install and update commands which makes it easier to automate restarting the cli when it fails.